### PR TITLE
Fixing request issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "moment": "^2.10.6",
     "moment-timezone": "^0.4.1",
     "mongodb": "^1.4.4",
-    "request-promise": "^1.0.2",
-    "robe": "^0.12.0"
+    "request": "^2.72.0",
+    "robe": "^1.0.0"
   }
 }

--- a/src/core/http.js
+++ b/src/core/http.js
@@ -1,5 +1,5 @@
 'use strict';
-const request = require('request-promise');
+const request = require('request');
 
 var optionsObj = {
     method: 'GET',
@@ -24,7 +24,12 @@ class Http {
         Object.keys(options).forEach( (key) => {
             data[key] = options[key];
         });
-        return request(data);
+        return new Promise( (resolve, reject) => {
+            request(data, (error, response) => {
+                if (error) reject(error);
+                else resolve(response);
+            });
+        });
     }
 
     /**

--- a/src/downloader/busDownloader.js
+++ b/src/downloader/busDownloader.js
@@ -21,17 +21,19 @@ class BusDownloader {
      * @return {Promise}
      */
     static fromURL(url, timeout) {
-        return Http.get(url, undefined, timeout).catch(function (error) {
-            error.body = { DATA: [], COLUMNS: [] };
-            return error;
-        }).then( response => {
+        return Http.get(url, undefined, timeout)
+        .then(response => response, error => error)
+        .then( response => {
             let msg = `[${url}] -> ${response.statusCode || response.code}`;
-            if(response.statusCode>=400) logger.error(msg);
+            if(response.statusCode>=400) {
+                logger.error(msg);
+                return BusDownloader.parseBody({ DATA: [], COLUMNS: [] });
+            }
             else logger.info(msg);
             return BusDownloader.parseBody(response.body);
         });
     }
-	
+
     /**
      * Preprocesses the request's output body 
      * @param {string} body - Request body

--- a/src/downloader/itineraryDownloader.js
+++ b/src/downloader/itineraryDownloader.js
@@ -34,17 +34,19 @@ class ItineraryDownloader {
      * @return {Promise}
      */
     static fromURL(url, timeout, line) {
-        return Http.get(url, undefined, timeout).catch(function (error) {
-            error.body = '';
-            return error;
-        }).then( (response) => {
+        return Http.get(url, undefined, timeout)
+        .then(response => response, error => error)
+        .then( (response) => {
             let msg = `[${url}] -> ${response.statusCode || response.code}`;
-            if(response.statusCode>=400) logger.error(msg);
-            else logger.info(msg);
+            if(response.statusCode>=400) {
+                logger.error(msg);
+                return ItineraryDownloader.parseBody(line, '');
+            }
+            logger.info(msg);
             return ItineraryDownloader.parseBody(line, response.body);
         });
     }
-	
+
     /**
      * Preprocesses the request's output body 
      * @param {string} lineQuery - Requested line 

--- a/test/core/http.js
+++ b/test/core/http.js
@@ -7,9 +7,9 @@ const express = require('express');
 
 
 describe('Http', () => {
-	
+
 	let http, server, addr;
-    
+
     before( () => {
         let app = express();
         let port = 3000;
@@ -32,11 +32,9 @@ describe('Http', () => {
 
         server = app.listen(port, () => addr = `http://localhost:${port}` );
     });
-    
-    after( () => {
-        server.close();
-    });
-    
+
+    after(() => server.close());
+
     it(`should read 'success' from the request to '${addr}'`, (done) => {
         Http.get(addr).then( response => {
             Assert.equal(response.statusCode, 200);
@@ -44,7 +42,7 @@ describe('Http', () => {
             done();
         });
     });
-    
+
     it(`should read 'long' from the request to '${addr}/long'`, (done) => {
         Http.get(`${addr}/long`).then( response => {
             Assert.equal(response.statusCode, 200);
@@ -52,12 +50,14 @@ describe('Http', () => {
             done();
         });
     });
-    
+
     it(`should end the request to '${addr}/toolong' when taking more than 5 sec to respond`, (done) => {
         let p = Http.get(`${addr}/toolong`, undefined, 5000);
-        p.catch( response => {
-            Assert.equal(response.error.code, 'ETIMEDOUT');
-            done();
+        p.then(
+            response => Assert(false, 'Request not aborted after 5 seconds.'),
+            error => {
+                Assert.equal(error.code, 'ETIMEDOUT');
+                done();
         });
     });
 });


### PR DESCRIPTION
Sometimes the server just stops in a request. This fix corrects this problem by removing the `request-promise` module and using the basic `request` module instead. Also, the `Promise` implementation now comes from default Node.js Promise class.
