### PR TITLE
Disable OSRM and fix "freeze" bug

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -43,7 +43,7 @@ function* loadItinerary(line) {
     let tmpItinerary = itineraries[line];
     if(!tmpItinerary) {
         logger.alert(`[${line}] Itinerary not found. Downloading...`);
-        tmpItinerary = yield ItineraryDownloader.fromLine(line, Config.provider.updateTimeout);
+        tmpItinerary = yield ItineraryDownloader.fromLine(line);
         logger.info(`[${line}] Saving Itinerary to database...`);
         itineraries[line] = tmpItinerary;
         yield itineraryDAO.save(tmpItinerary);
@@ -65,9 +65,9 @@ function concatBusList(a, b) {
 function* iteration() {
     logger.info('Downloading bus states...');
     var busList = [];
-    busList = busList.concat(yield BusDownloader.fromURL(getURL('REGULAR', Config.provider.updateTimeout)));
-    busList = busList.concat(yield BusDownloader.fromURL(getURL('REGULAR-NEW', Config.provider.updateTimeout)));
-    busList = busList.concat(yield BusDownloader.fromURL(getURL('BRT', Config.provider.updateTimeout)));
+    busList = busList.concat(yield BusDownloader.fromURL(getURL('REGULAR')));
+    busList = busList.concat(yield BusDownloader.fromURL(getURL('REGULAR-NEW')));
+    busList = busList.concat(yield BusDownloader.fromURL(getURL('BRT')));
 
     logger.info(`${busList.length} found. Processing...`);
 

--- a/src/app.js
+++ b/src/app.js
@@ -141,7 +141,7 @@ function* iteration() {
         logger.error(e);
     }
 
-    setTimeout(() => { spawn(iteration); }, timeout);
+    setTimeout(() => { spawn(iteration).catch(onError); }, timeout);
 }
 
 spawn(function*(){

--- a/src/app.js
+++ b/src/app.js
@@ -155,9 +155,10 @@ spawn(function*(){
     logger.info('Loading itineraries...');
     itineraries = prepareItineraries(yield itineraryDAO.getAll());
     logger.info(`Itineraries retrieved: ${Object.keys(itineraries).length}`);
-    spawn(iteration);
-})
-.catch(function(error) {
-    logger.fatal(error.stack);
+    spawn(iteration).catch(onError);
+}).catch(onError);
+
+function onError(err) {
+    logger.fatal(err.stack);
     MainProcess.exit(1);
-});
+}

--- a/src/config.js
+++ b/src/config.js
@@ -7,6 +7,7 @@ module.exports = {
     root: __dirname,
     cache: '/tmp/riobus/cache',
     historySize: 10,
+    ignoreDirection: process.env.RIOBUS_IGNORE_DIRECTION || false,
     ignoreHistoryCollection: process.env.RIOBUS_IGNORE_HISTORY_COLLECTION || false,
     logs: {
         runtime: '/tmp/riobus/log/runtime.log',

--- a/src/core/http.js
+++ b/src/core/http.js
@@ -35,8 +35,8 @@ class Http {
     /**
      * Makes GET request
      * @param {string} host - Host URL
-     * @param {Object} data - Data to be sent (Optional)
      * @param {Object} headers - Headers to be set (Optional)
+     * @param {number} timeout - Timeout for the request in milliseconds (Optional)
      * @returns {Promise}
      */
     static get(host, headers, timeout) {

--- a/src/downloader/busDownloader.js
+++ b/src/downloader/busDownloader.js
@@ -1,6 +1,7 @@
 'use strict';
 const Bus = require('../model/bus');
 const BusUtils = require('../utils/busUtils');
+const Config = require('../config');
 const Core = require('../core');
 const Http = Core.Http;
 const ItineraryDownloader = require('./itineraryDownloader');
@@ -20,8 +21,8 @@ class BusDownloader {
      * @param {string} url - External provider service address
      * @return {Promise}
      */
-    static fromURL(url, timeout) {
-        return Http.get(url, undefined, timeout)
+    static fromURL(url) {
+        return Http.get(url, undefined, Config.provider.updateTimeout)
         .then(response => response, error => error)
         .then( response => {
             switch (response.statusCode) {

--- a/src/downloader/itineraryDownloader.js
+++ b/src/downloader/itineraryDownloader.js
@@ -1,4 +1,5 @@
 'use strict';
+const Config = require('../config');
 const Core = require('../core');
 const Http = Core.Http;
 const Itinerary = require('../model/itinerary');
@@ -6,7 +7,6 @@ const ItinerarySpot = require('../model/itinerarySpot');
 const LoggerFactory = Core.LoggerFactory;
 const Spot = require('../model/spot');
 const Strings = require('../strings');
-const Config = require('../config');
 
 const logger = LoggerFactory.getRuntimeLogger();
 
@@ -15,16 +15,16 @@ const logger = LoggerFactory.getRuntimeLogger();
  * @class {ItineraryDownloader}
  */
 class ItineraryDownloader {
-	
+
     /**
      * Downloads the data for a given bus line
      * @param {string} line - Bus line
      * @return {Promise}
      */
-	static fromLine(line, timeout) {
+	static fromLine(line) {
 		let urlConfig = Config.provider;
 		var url = `http://${urlConfig.host}${urlConfig.path.itinerary.replace('$$', line)}`;
-		return ItineraryDownloader.fromURL(url, timeout, line);
+		return ItineraryDownloader.fromURL(url, line);
 	}
     
 	
@@ -33,8 +33,8 @@ class ItineraryDownloader {
      * @param {string} url - External provider service address
      * @return {Promise}
      */
-    static fromURL(url, timeout, line) {
-        return Http.get(url, undefined, timeout)
+    static fromURL(url, line) {
+        return Http.get(url, undefined, Config.provider.updateTimeout)
         .then(response => response, error => error)
         .then( response => {
             switch (response.statusCode) {


### PR DESCRIPTION
- Add an environment flag `RIOBUS_DISABLE_DIRECTION` to disable the direction algorithm, temporarily removing the OSRM dependency.
- Fix a bug that caused the process to freeze
- Fix a bug that didn't set a timeout for the HTTP requests
